### PR TITLE
change insertion to not be recursive by pre-flattening the input

### DIFF
--- a/test/test.py
+++ b/test/test.py
@@ -57,10 +57,14 @@ def test_pp_to_def():
     translator = JSONSchemaToPostgres(schema)
     con = psycopg2.connect('host=localhost dbname=jsonschema2db-test')
     translator.create_tables(con)
-    translator.insert_items(con, {33: {'aBunchOfDocuments': {'xyz': {'url': 'http://baz.bar'}},
-                                       'moreDocuments': {'abc': {'url': 'https://banana'}}}})
+    failure_count = translator.insert_items(con, {33: [(('aBunchOfDocuments', 'xyz', 'url'), 'http://baz.bar'),
+                                                       (('moreDocuments', 'abc', 'url'), 'https://banana'),
+                                                       (('moreDocuments', 'abc', 'url'), ['wrong-type']),
+                                                       (('moreDocuments', 'abc'), 'broken-value-ignore')]})
     translator.create_links(con)
     translator.analyze(con)
+
+    assert failure_count == {('moreDocuments', 'abc'): 1, ('moreDocuments', 'abc', 'url'): 1}
 
     assert list(query(con, 'select count(1) from root')) == [(1,)]
     assert list(query(con, 'select count(1) from file')) == [(2,)]


### PR DESCRIPTION
We had some broken data where one path is a prefix of another. `insert_items` is flexible enough to handle such errors, but unfortunately since the API required passing in a nested dict, this wasn't even possible for `insert_items` to handle.

Updated the interface so that `insert_items` also handles a list of pairs specifying `(path, value)`. As a part of that, I had to refactor the insertion to be not recursive any more, having a separate helper that pre-flattens any nested objects.