### PR TITLE
handle coercion of date/timestamp types

### DIFF
--- a/jsonschema2db.py
+++ b/jsonschema2db.py
@@ -360,7 +360,7 @@ class JSONSchemaToDatabase:
                 # TODO: might want to use a thread pool for this
                 batch_random = '%012d' % random.randint(0, 999999999999)
                 for table, fn in temp_files.items():
-                    s3_path = '/%s/%s/%s.csv.gz' % (self._s3_prefix, batch_random, table)
+                    s3_path = '/%s/%s/%s.csv' % (self._s3_prefix, batch_random, table)
                     if self._debug:
                         print('Uploading data for table %s from %s (%d bytes) to %s' % (table, fn, os.path.getsize(fn), s3_path), file=sys.stderr)
                     self._s3_client.upload_file(Filename=fn, Bucket=self._s3_bucket, Key=s3_path)

--- a/test/test_time_schema.json
+++ b/test/test_time_schema.json
@@ -1,0 +1,22 @@
+{
+    "$schema": "http://json-schema.org/schema#",
+    "type": "object",
+    "definitions": {
+	"date": {
+	    "type": "string",
+	    "format": "string"
+	},
+	"timestamp": {
+	    "type": "string",
+	    "format": "date-time"
+	}
+    },
+    "properties": {
+        "ts": {
+	    "$ref": "#/definitions/timestamp"
+        },
+	"d": {
+	    "$ref": "#/definitions/date"
+        }
+    }
+}


### PR DESCRIPTION
Turns out we're doing some nonstandard json schema things here with dates and timestamps.

Since we're already doing it, we might as well make it work. I'll make sure to document these somewhat confusing "features" later.