### PR TITLE
Allowing newer version of dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(name='JSONSchema2DB',
       author_email='erikbern@better.com',
       py_modules=['jsonschema2db'],
       install_requires=[
-          'change_case==0.5.2',
-          'iso8601==0.1.12',
-          'psycopg2==2.7.2'
+          'change_case>=0.5.2',
+          'iso8601>=0.1.12',
+          'psycopg2>=2.7.2'
       ])


### PR DESCRIPTION
This was causing pip to downgrade pycopg2 if it was installed after. Hopefully newer libs didn't break it. Tests in docker passed.