### PR TITLE
fix: rename psycopg package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,5 +21,5 @@ setup(name='JSONSchema2DB',
       install_requires=[
           'change_case>=0.5.2',
           'iso8601>=0.1.12',
-          'psycopg2>=2.7.2'
+          'psycopg2-binary>=2.7.2'
       ])


### PR DESCRIPTION
This was breaking installation for me, and i believe this fixed it (please double check this makes sense).

believe this issue is probably related:
https://github.com/better/jsonschema2db/issues/45